### PR TITLE
Allow custom patterns for env file copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Auto-refresh of worktree list after operations
 - Visual indicators to distinguish main worktree from feature worktrees
 - Progress notifications during worktree operations
+- Copy of `.env` and other local config files from subdirectories when creating a worktree
+- User-defined local file patterns via `git-worktree-cursor.localFilePatterns`
 - Input validation for branch names
 - Error handling with user-friendly messages
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A VS Code extension that simplifies Git worktree management with seamless Cursor
 - 🗑️ **Easy Cleanup**: Delete single or multiple worktrees with confirmation
 - 📁 **Organized Structure**: Worktrees are automatically organized in a dedicated folder
 - 🔄 **Real-time Updates**: The worktree list refreshes automatically after operations
+- 📄 **Config File Sync**: `.env` and other local config files from any subdirectory are copied into new worktrees. Additional patterns can be configured via `git-worktree-cursor.localFilePatterns`.
 
 ## 📦 Installation
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git-worktree-cursor",
   "displayName": "Git Worktree + cursor Editor",
   "description": "Easily manage Git worktrees and open them in Cursor editor with a beautiful sidebar interface",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "publisher": "RikuOgawa",
   "icon": "icon.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -88,9 +88,19 @@
       "properties": {
         "git-worktree-cursor.localFilePatterns": {
           "type": "array",
-          "description": "追加でコピーするローカルファイルのパターン",
-          "items": { "type": "string" },
-          "default": []
+          "description": "Patterns for additional local files to copy. Supports glob patterns like '*.log', 'config/*.json', '**/*.local'",
+          "items": { 
+            "type": "string",
+            "description": "Glob pattern (e.g. '*.log', 'config/*.json', '**/*.local')"
+          },
+          "default": [],
+          "examples": [
+            "*.log",
+            "config/*.json",
+            "**/*.local",
+            ".env*",
+            "secrets/*.yml"
+          ]
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,18 @@
           "group": "inline"
         }
       ]
+    },
+    "configuration": {
+      "type": "object",
+      "title": "Git Worktree + cursor Editor",
+      "properties": {
+        "git-worktree-cursor.localFilePatterns": {
+          "type": "array",
+          "description": "追加でコピーするローカルファイルのパターン",
+          "items": { "type": "string" },
+          "default": []
+        }
+      }
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,21 @@ import { promisify } from "util";
 
 const exec = promisify(cp.exec);
 
-// ローカルファイルのパターン定義
-const LOCAL_FILE_PATTERNS = [".env*", "*.local.*", "config.local.*", ".vscode/settings.json"];
+// デフォルトのローカルファイルパターン
+const DEFAULT_LOCAL_FILE_PATTERNS = [
+  "**/.env*",
+  "**/*.local.*",
+  "**/config.local.*",
+  ".vscode/settings.json",
+];
+
+// 設定から追加のパターンを取得
+function getLocalFilePatterns(): string[] {
+  const configPatterns = vscode.workspace
+    .getConfiguration("git-worktree-cursor")
+    .get<string[]>("localFilePatterns", []);
+  return [...DEFAULT_LOCAL_FILE_PATTERNS, ...configPatterns];
+}
 
 interface Worktree {
   path: string;
@@ -31,7 +44,7 @@ class WorktreeItem extends vscode.TreeItem {
 // ローカルファイルをコピーする関数
 async function copyLocalFiles(sourcePath: string, targetPath: string): Promise<void> {
   try {
-    for (const pattern of LOCAL_FILE_PATTERNS) {
+    for (const pattern of getLocalFilePatterns()) {
       const sourceFiles = await findMatchingFiles(sourcePath, pattern);
 
       for (const sourceFile of sourceFiles) {


### PR DESCRIPTION
## Summary
- allow users to specify additional local file patterns via `git-worktree-cursor.localFilePatterns`
- document the new setting in the README
- update changelog

## Testing
- `npm run compile` *(fails: Cannot find module)*
- `npm test` *(fails: Cannot find module)*


------
https://chatgpt.com/codex/tasks/task_e_683d5c61cbe4832a8d17ba4702bd6fa4