### PR TITLE
ローカルファイルのパターンに「.vercel」を追加し、コピーされるように変更

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { promisify } from "util";
 const exec = promisify(cp.exec);
 
 // ローカルファイルのパターン定義
-const LOCAL_FILE_PATTERNS = [".env*", "*.local.*", "config.local.*", ".vscode/settings.json"];
+const LOCAL_FILE_PATTERNS = [".env*", "*.local.*", "config.local.*", ".vscode/settings.json", ".vercel"];
 
 interface Worktree {
   path: string;


### PR DESCRIPTION
## 概要

ローカルファイルのパターンに `.vercel` を追加し、コピーされるように変更しました。

## 対応内容

- `.vercel` ディレクトリをローカルファイルのパターンに追加
- `.vercel` ディレクトリも他のローカル設定ファイルと同様にコピー対象とするよう変更

## 変更点

### コミット差分

### 27ab886 ローカルファイルのパターンに「.vercel」を追加し、コピーされるように変更

- `src/extension.ts` 内の `LOCAL_FILE_PATTERNS` に `.vercel` を追加

## 動作確認方法

- `.vercel` ディレクトリがコピーされることを確認する

## 補足
