### PR TITLE
ローカルファイルのパターンに「.vercel*」を追加し、正しくワークツリーにコピーされるように

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { promisify } from "util";
 const exec = promisify(cp.exec);
 
 // ローカルファイルのパターン定義
-const LOCAL_FILE_PATTERNS = [".env*", "*.local.*", "config.local.*", ".vscode/settings.json"];
+const LOCAL_FILE_PATTERNS = [".env*", "*.local.*", "config.local.*", ".vscode/settings.json", ".vercel*"];
 
 interface Worktree {
   path: string;


### PR DESCRIPTION
## 概要

ローカルファイルのパターン `.vercel`が`*`が入っておらず正しくコピーされていませんでした。
`*` を追加し、コピーされるように変更しました。

## 変更点

- `src/extension.ts` 内の `LOCAL_FILE_PATTERNS` の`.vercel`を `.vercel*` に修正

## 動作確認方法

- `.vercel` ディレクトリがコピーされることを確認する

## 補足
