### PR TITLE
Fix popup cancel handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -377,7 +377,7 @@ export function activate(context: vscode.ExtensionContext) {
           "Cancel"
         );
 
-        if (confirm === "Cancel") {
+        if (confirm !== "Directory and Branch" && confirm !== "Directory Only") {
           return;
         }
 


### PR DESCRIPTION
## Summary
- handle closing confirmation popup the same as Cancel

## Testing
- `npm test` *(fails: Cannot find module 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_6846c722d830832a8512692c7626f5f5